### PR TITLE
Fix bundle identifier errors in examples

### DIFF
--- a/socket-features/extension/socket.ini
+++ b/socket-features/extension/socket.ini
@@ -24,7 +24,7 @@ copyright = "(C) Socket Supply, Co. 2023"
 lang = "en-us"
 
 [meta.bundle]
-identifier = "co.socketsupply.ios."
+identifier = "co.socketsupply.ios"
 
 [meta.file]
 limit = 1024

--- a/socket-features/multiple-windows/socket.ini
+++ b/socket-features/multiple-windows/socket.ini
@@ -32,6 +32,7 @@ flags = "-g"
 [meta]
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 version = 1.0.0
+bundle_identifier = "com.beepboop"
 
 [window]
 ; The initial height of the first window.

--- a/socket-features/node-backend-bundled/socket.ini
+++ b/socket-features/node-backend-bundled/socket.ini
@@ -32,6 +32,7 @@ flags = "-g"
 [meta]
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 version = 1.0.0
+bundle_identifier = "com.beepboop"
 
 [linux]
 ; The command to execute to spawn the "back-end" process.


### PR DESCRIPTION
The `extension` example is still broken, and `node-backend-bundled` seems to be having issues too, but this at least addresses the problems in https://github.com/socketsupply/socket-examples/issues/76